### PR TITLE
added a custom serialization binder, with this it's possible to use t…

### DIFF
--- a/FakeTextGenerator/Corpus.cs
+++ b/FakeTextGenerator/Corpus.cs
@@ -7,6 +7,8 @@ using System.Text.RegularExpressions;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Serialization.Formatters;
+using FakeTextGenerator;
 
 namespace ET.FakeText
 {
@@ -110,6 +112,7 @@ namespace ET.FakeText
             using (Stream stream = executingAssm.GetManifestResourceStream(name))
             {
                 BinaryFormatter serializer = new BinaryFormatter();
+                serializer.Binder = new FaketextGeneratorAssemblyIndependentBinder();
                 return serializer.Deserialize(stream) as Corpus;
             }
         }

--- a/FakeTextGenerator/FakeTextGenerator.csproj
+++ b/FakeTextGenerator/FakeTextGenerator.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FaketextGeneratorAssemblyIndependentBinder.cs" />
     <Compile Include="Corpus.cs" />
     <Compile Include="LetterStats.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/FakeTextGenerator/FaketextGeneratorAssemblyIndependentBinder.cs
+++ b/FakeTextGenerator/FaketextGeneratorAssemblyIndependentBinder.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using ET.FakeText;
+
+namespace FakeTextGenerator
+{
+    sealed class FaketextGeneratorAssemblyIndependentBinder : SerializationBinder
+    {
+        public override Type BindToType(string assemblyName, string typeName)
+        {
+            if (typeName == typeof (Corpus).FullName)
+            {
+                return typeof (Corpus);
+            }
+            if (typeName == typeof (LetterStats).FullName)
+            {
+                return typeof (LetterStats);
+            }
+            if (typeName.Contains("List`1") && typeName.Contains("LetterStats"))
+            {
+                return typeof (List<LetterStats>);
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
…his dll as reference in dynamically loaded solutions (e.g. MEF) there was a serialization exception because of the serialization happened with the version 1.0.0.0 of this dll but we use 1.0.1.0 now
